### PR TITLE
Fix Node example

### DIFF
--- a/tutorial.rst
+++ b/tutorial.rst
@@ -86,6 +86,8 @@ The most notable change is that, rather than trying to join a channel's chat, we
 
         return beam.game.join(stream);
     }).then(function (res) {
+        res.body.remote = res.body.address;
+        res.body.channel = stream;
         var robot = new Tetris.Robot(res.body);
         robot.handshake();
 
@@ -144,9 +146,11 @@ The Final Code
     }).attempt().then(function () {
         return beam.game.join(stream);
     }).then(function (res) {
+        res.body.remote = res.body.address;
+        res.body.channel = stream;
         var robot = new Tetris.Robot(res.body);
         robot.handshake();
-
+        
         robot.on('report', function (report) {
             var mouse = robot.getMousePos();
             rjs.moveMouse(


### PR DESCRIPTION
The node connector expects the remote address to be in `options.remote` and not `address` in addition to this you need to pass the channel id in `options.channel`.